### PR TITLE
Fix issue 6

### DIFF
--- a/03-data-types-structures.ipynb
+++ b/03-data-types-structures.ipynb
@@ -526,16 +526,14 @@
     "\n",
     "Sequences share the following operations\n",
     "\n",
-    "<table>\n",
-    "<tr><td>`a[i]`</td><td>returns *i*-th element of `a`</td></tr>\n",
-    "<tr><td>`a[i:j]`</td><td>returns elements *i* up to *j* − 1</td></tr>\n",
-    "<tr><td>`len(a)`</td><td>returns number of elements in sequence</td></tr>\n",
-    "<tr><td>`min(a)`</td><td>returns smallest value in sequence</td></tr>\n",
-    "<tr><td>`max(a)`</td><td>returns largest value in sequence</td></tr>\n",
-    "<tr><td>`x in a`</td><td>returns `True` if `x` is element in `a`</td></tr>\n",
-    "<tr><td>`a + b`</td><td>concatenates `a` and `b`</td></tr>\n",
-    "<tr><td>`n * a`</td><td>creates `n` copies of sequence `a`</td></tr>\n",
-    "</table>"
+    "* `a[i]` returns i-th element of `a`\n",
+    "* `a[i:j]` returns elements i up to j-1\n",
+    "* `len(a)` returns number of elements in sequence\n",
+    "* `min(a)` returns smallest value in sequence\n",
+    "* `max(a)` returns largest value in sequence\n",
+    "* `x in a` returns `True` if `x` is element in `a`\n",
+    "* `a + b` concatenates `a` and `b`\n",
+    "* `n * a` creates `n` copies of sequence `a`"
    ]
   },
   {
@@ -3620,7 +3618,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
(https://github.com/fangohr/introduction-to-python-for-computational-science-and-engineering/issues/6)

Problem was that the '-' in j-1 was not the normal minus but some
other type of hyphen, which in the translation to LaTeX disappeared.

I also changed the embedded html table to an itemised list; as the
embedded table didn't render in the notebook very well, and neither in
html (only in the latex output).

There is further an issue for markdown (?) parsing the line

 `a[i:j]` returns elements *i* up to *j* − 1

correctly: it makes "up to" italics, not "i" and "j". To avoid that, I
have taken out the italic printing of i and j at this point.