### PR TITLE
current version of pandas needs pyarrow as dependency

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,5 +3,6 @@ scipy
 sympy
 matplotlib
 pandas
+pyarrow
 ipython
 pytest


### PR DESCRIPTION
otherwise a warning is displayed when we import